### PR TITLE
Ticket-001: Reorganize modules within scraper and s3 directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 venv/
 .ipynb_checkpoints/
+__pycache__/

--- a/chinese-news-aggregator/etl/s3/constants.py
+++ b/chinese-news-aggregator/etl/s3/constants.py
@@ -1,0 +1,3 @@
+from pathlib import Path
+
+DATA_DIRECTORY = Path.home() / "OneDrive/2021/Programming/python/chinese-news-aggregator/chinese-news-aggregator/data"

--- a/chinese-news-aggregator/etl/s3/helpers.py
+++ b/chinese-news-aggregator/etl/s3/helpers.py
@@ -2,7 +2,7 @@ import boto3
 import datetime
 
 
-def upload_file(file_name, bucket, key=None):
+def upload_file(file_name: str, bucket: str, key=None):
     """This function takes the updated article data file from the data directory and uploads it to
     AWS S3 using the AWS SDK for Python while providing it with a S3 Key based on the data source, section
     from the news site, and the current date.

--- a/chinese-news-aggregator/etl/s3/helpers.py
+++ b/chinese-news-aggregator/etl/s3/helpers.py
@@ -1,0 +1,21 @@
+import boto3
+import datetime
+
+
+def upload_file(file_name, bucket, key=None):
+    """This function takes the updated article data file from the data directory and uploads it to
+    AWS S3 using the AWS SDK for Python while providing it with a S3 Key based on the data source, section
+    from the news site, and the current date.
+    
+    # file_name is the path to the file on the local machine
+    # bucket is the bucket name to upload to
+    # key is the name the file will have in s3"""
+
+    today_str = (datetime.date.today()).strftime("%Y-%m-%d")
+
+    if key is None:
+        key = f"china-daily/china-us/" + today_str + ".json"
+
+   
+    s3 = boto3.client("s3")
+    s3.upload_file(file_name, bucket, key)

--- a/chinese-news-aggregator/etl/s3/s3_upload_files.py
+++ b/chinese-news-aggregator/etl/s3/s3_upload_files.py
@@ -1,32 +1,10 @@
-import boto3
 import os
-import datetime
-from pathlib import Path
-
-
-def upload_file(file_name, bucket, key=None):
-    """This function takes the updated article data file from the data directory and uploads it to
-    AWS S3 using the AWS SDK for Python while providing it with a S3 Key based on the data source, section
-    from the news site, and the current date.
-    
-    # file_name is the path to the file on the local machine
-    # bucket is the bucket name to upload to
-    # key is the name the file will have in s3"""
-
-    today_str = (datetime.date.today()).strftime("%Y-%m-%d")
-
-    if key is None:
-        key = f"china-daily/china-us/" + today_str + ".json"
-
-   
-    s3 = boto3.client("s3")
-    s3.upload_file(file_name, bucket, key)
+import helpers
+import constants
 
 
 
 # Change to chinese-news-aggregator directory
-# data_directory = Path.home() / "OneDrive - Jobin Machine, Inc/2021/chinese-news-aggregator/app/data"
-data_directory = Path.home() / "OneDrive/2021/Programming/python/chinese-news-aggregator/chinese-news-aggregator/data"
-os.chdir(data_directory)
+os.chdir(constants.DATA_DIRECTORY)
 
-upload_file("article-data-from-new-links.json", "daily-data-collection")
+helpers.upload_file("article-data-from-new-links.json", "daily-data-collection")

--- a/chinese-news-aggregator/etl/s3/s3_upload_files.py
+++ b/chinese-news-aggregator/etl/s3/s3_upload_files.py
@@ -3,7 +3,6 @@ import helpers
 import constants
 
 
-
 # Change to chinese-news-aggregator directory
 os.chdir(constants.DATA_DIRECTORY)
 

--- a/chinese-news-aggregator/etl/scraper/constants.py
+++ b/chinese-news-aggregator/etl/scraper/constants.py
@@ -1,0 +1,3 @@
+from pathlib import Path
+
+PROJECT_DIRECTORY = Path.home() / "OneDrive/2021/Programming/python/chinese-news-aggregator"

--- a/chinese-news-aggregator/etl/scraper/helpers.py
+++ b/chinese-news-aggregator/etl/scraper/helpers.py
@@ -1,0 +1,104 @@
+# Article Links Func 1:  Collect link from primary article (top left of webpage, the left portion of html section <div class="tw2" section)
+def collect_primary_article_link(soup_object, list_of_secure_links):
+    """This function takes a soup object and a list as inputs, parses thru the soup object to find
+    primary article link (main article at the top left of the page), and appends the link to the list
+    of secure links."""
+
+    # Collect from webpage primary article
+    primary_article = soup_object.find("span", class_="tw2_l_t")
+    primary_article_link = primary_article.a.get("href")
+    secure_link = "https:" + primary_article_link
+
+    list_of_secure_links.append(secure_link)
+
+
+# Article Links Func 2:  Collect links from secondary articles (top right of webpage. the right portion of html section <div class="tw2" section)
+def collect_secondary_article_links(soup_object, list_of_secure_links):
+    """This function takes a soup object and a list as inputs, parses thru the soup object to find
+    secondary article links (main articles at the top right of the page), and appends the links to the list
+    of secure links."""
+    
+    secondary_articles = soup_object.find_all("div", class_="tBox2")
+
+    for secondary_article in secondary_articles:
+        secondary_article_link = secondary_article.a.get("href")
+        secure_link = "https:" + secondary_article_link
+
+        list_of_secure_links.append(secure_link)
+
+
+# Article Links Func 3:  Collect links from list of articles (center of webpage below the primary and secondary articles section, the list of <div class="mb10 tw3_01_2" sections)
+def collect_listed_article_links(soup_object, list_of_secure_links):
+    """This function takes a soup object and a list as inputs, parses thru the soup object to find
+    listed articles links (list of articles in the center of the page), and appends the links to the list
+    of secure links."""
+
+    articles_list = soup_object.find_all("span", class_="tw3_01_2_t")
+
+    for listed_article in articles_list:
+        listed_article_link = listed_article.a.get("href")
+        secure_link = "https:" + listed_article_link
+
+        list_of_secure_links.append(secure_link)
+
+
+
+
+
+def collect_all_article_content(soup_object):
+    """This function takes a BeautifulSoup soup object as input and returns all of the HTML content within
+    the specified tags. The returned content contains all of the potential data we will be extracting."""
+
+    all_article_content = soup_object.find("div", class_="lft_art")
+
+    return all_article_content
+
+
+def collect_article_date(all_article_content):
+    """This function takes the subset of HTML data from a webpage provided by the collect_all_article_content()
+    function and parses thru it to find the date that the article was posted."""
+
+    date_element = all_article_content.find("span", class_="info_l")
+    date = date_element.text.split("|")[-1].strip()[9:-6]
+
+    return date
+
+
+def collect_article_title(all_article_content):
+    """This function takes the subset of HTML data from a webpage provided by the collect_all_article_content()
+    function and parses thru it to find the title of the article."""
+
+    title_element = all_article_content.find("h1")
+    title = title_element.text.strip()
+
+    return title
+
+
+def collect_article_body(all_article_content):
+    """This function takes the subset of HTML data from a webpage provided by the collect_all_article_content()
+    function and parses thru it to find the body of the article."""
+
+    article_body = []
+
+    body_element = all_article_content.find_all("p")
+    for paragraph in body_element:
+        article_body.append(paragraph.text.strip())
+
+    body = " ".join(article_body).strip()
+
+    return body
+
+
+def create_filtered_dataframe(data, list_of_columns):
+    """This function takes a list of lists and a list of the column names, creates a DataFrame, and filters that
+    DataFrame by date to keep only date from articles posted on the current date."""
+
+    df = pd.DataFrame(data, columns=list_of_columns)
+    df["date"] = pd.to_datetime(df["date"])
+
+    today = datetime.date.today()
+    today_datetime = pd.to_datetime(today)
+
+    df = df[df["date"] == today_datetime]
+
+    return df

--- a/chinese-news-aggregator/etl/scraper/helpers.py
+++ b/chinese-news-aggregator/etl/scraper/helpers.py
@@ -1,3 +1,7 @@
+import pandas as pd
+import datetime
+
+
 # Article Links Func 1:  Collect link from primary article (top left of webpage, the left portion of html section <div class="tw2" section)
 def collect_primary_article_link(soup_object, list_of_secure_links):
     """This function takes a soup object and a list as inputs, parses thru the soup object to find

--- a/chinese-news-aggregator/etl/scraper/helpers.py
+++ b/chinese-news-aggregator/etl/scraper/helpers.py
@@ -3,7 +3,7 @@ import datetime
 
 
 # Article Links Func 1:  Collect link from primary article (top left of webpage, the left portion of html section <div class="tw2" section)
-def collect_primary_article_link(soup_object, list_of_secure_links):
+def collect_primary_article_link(soup_object, list_of_secure_links: list):
     """This function takes a soup object and a list as inputs, parses thru the soup object to find
     primary article link (main article at the top left of the page), and appends the link to the list
     of secure links."""
@@ -17,7 +17,7 @@ def collect_primary_article_link(soup_object, list_of_secure_links):
 
 
 # Article Links Func 2:  Collect links from secondary articles (top right of webpage. the right portion of html section <div class="tw2" section)
-def collect_secondary_article_links(soup_object, list_of_secure_links):
+def collect_secondary_article_links(soup_object, list_of_secure_links: list):
     """This function takes a soup object and a list as inputs, parses thru the soup object to find
     secondary article links (main articles at the top right of the page), and appends the links to the list
     of secure links."""
@@ -32,7 +32,7 @@ def collect_secondary_article_links(soup_object, list_of_secure_links):
 
 
 # Article Links Func 3:  Collect links from list of articles (center of webpage below the primary and secondary articles section, the list of <div class="mb10 tw3_01_2" sections)
-def collect_listed_article_links(soup_object, list_of_secure_links):
+def collect_listed_article_links(soup_object, list_of_secure_links: list):
     """This function takes a soup object and a list as inputs, parses thru the soup object to find
     listed articles links (list of articles in the center of the page), and appends the links to the list
     of secure links."""
@@ -46,9 +46,7 @@ def collect_listed_article_links(soup_object, list_of_secure_links):
         list_of_secure_links.append(secure_link)
 
 
-
-
-
+# Article Content Collection Func 1
 def collect_all_article_content(soup_object):
     """This function takes a BeautifulSoup soup object as input and returns all of the HTML content within
     the specified tags. The returned content contains all of the potential data we will be extracting."""
@@ -58,6 +56,7 @@ def collect_all_article_content(soup_object):
     return all_article_content
 
 
+# Article Content Collection Func 2
 def collect_article_date(all_article_content):
     """This function takes the subset of HTML data from a webpage provided by the collect_all_article_content()
     function and parses thru it to find the date that the article was posted."""
@@ -68,6 +67,7 @@ def collect_article_date(all_article_content):
     return date
 
 
+# Article Content Collection Func 3
 def collect_article_title(all_article_content):
     """This function takes the subset of HTML data from a webpage provided by the collect_all_article_content()
     function and parses thru it to find the title of the article."""
@@ -78,6 +78,7 @@ def collect_article_title(all_article_content):
     return title
 
 
+# Article Content Collection Func 4
 def collect_article_body(all_article_content):
     """This function takes the subset of HTML data from a webpage provided by the collect_all_article_content()
     function and parses thru it to find the body of the article."""
@@ -93,7 +94,8 @@ def collect_article_body(all_article_content):
     return body
 
 
-def create_filtered_dataframe(data, list_of_columns):
+# Article Content Collection Func 5
+def create_filtered_dataframe(data: list[list[str]], list_of_columns: list[str]):
     """This function takes a list of lists and a list of the column names, creates a DataFrame, and filters that
     DataFrame by date to keep only date from articles posted on the current date."""
 

--- a/chinese-news-aggregator/etl/scraper/scraper_pt_1.py
+++ b/chinese-news-aggregator/etl/scraper/scraper_pt_1.py
@@ -1,13 +1,13 @@
 import os
 import json
-from pathlib import Path
 import requests
 from bs4 import BeautifulSoup
+import helpers
+import constants
 
 
 # Change to chinese-news-aggregator directory
-pipeline_directory = Path.home() / "OneDrive/2021/Programming/python/chinese-news-aggregator"
-os.chdir(pipeline_directory)
+os.chdir(constants.PROJECT_DIRECTORY)
 
 
 # Collect html code from china-us section page on China Daily website and create soup object
@@ -19,14 +19,14 @@ soup = BeautifulSoup(page.content, "html.parser")
 
 # Collect article links
 secure_links = []
-funcs = [collect_primary_article_link, collect_secondary_article_links, collect_listed_article_links]
+funcs = [helpers.collect_primary_article_link, helpers.collect_secondary_article_links, helpers.collect_listed_article_links]
 
 for func in funcs:
     func(soup, secure_links)
 
 
 # Create json file containing all potential new links for the current day
-file_destination = pipeline_directory / "chinese-news-aggregator/data/potential-new-links.json"
+file_destination = constants.PROJECT_DIRECTORY / "chinese-news-aggregator/data/potential-new-links.json"
 
 with open(file_destination, "w") as file:
     json.dump(secure_links, file, indent=4)

--- a/chinese-news-aggregator/etl/scraper/scraper_pt_1.py
+++ b/chinese-news-aggregator/etl/scraper/scraper_pt_1.py
@@ -5,52 +5,6 @@ import requests
 from bs4 import BeautifulSoup
 
 
-# Article Links Func 1:  Collect link from primary article (top left of webpage, the left portion of html section <div class="tw2" section)
-def collect_primary_article_link(soup_object, list_of_secure_links):
-    """This function takes a soup object and a list as inputs, parses thru the soup object to find
-    primary article link (main article at the top left of the page), and appends the link to the list
-    of secure links."""
-
-    # Collect from webpage primary article
-    primary_article = soup_object.find("span", class_="tw2_l_t")
-    primary_article_link = primary_article.a.get("href")
-    secure_link = "https:" + primary_article_link
-
-    list_of_secure_links.append(secure_link)
-
-
-# Article Links Func 2:  Collect links from secondary articles (top right of webpage. the right portion of html section <div class="tw2" section)
-def collect_secondary_article_links(soup_object, list_of_secure_links):
-    """This function takes a soup object and a list as inputs, parses thru the soup object to find
-    secondary article links (main articles at the top right of the page), and appends the links to the list
-    of secure links."""
-    
-    secondary_articles = soup_object.find_all("div", class_="tBox2")
-
-    for secondary_article in secondary_articles:
-        secondary_article_link = secondary_article.a.get("href")
-        secure_link = "https:" + secondary_article_link
-
-        list_of_secure_links.append(secure_link)
-
-
-# Article Links Func 3:  Collect links from list of articles (center of webpage below the primary and secondary articles section, the list of <div class="mb10 tw3_01_2" sections)
-def collect_listed_article_links(soup_object, list_of_secure_links):
-    """This function takes a soup object and a list as inputs, parses thru the soup object to find
-    listed articles links (list of articles in the center of the page), and appends the links to the list
-    of secure links."""
-
-    articles_list = soup_object.find_all("span", class_="tw3_01_2_t")
-
-    for listed_article in articles_list:
-        listed_article_link = listed_article.a.get("href")
-        secure_link = "https:" + listed_article_link
-
-        list_of_secure_links.append(secure_link)
-
-
-
-
 # Change to chinese-news-aggregator directory
 pipeline_directory = Path.home() / "OneDrive/2021/Programming/python/chinese-news-aggregator"
 os.chdir(pipeline_directory)

--- a/chinese-news-aggregator/etl/scraper/scraper_pt_2.py
+++ b/chinese-news-aggregator/etl/scraper/scraper_pt_2.py
@@ -7,67 +7,6 @@ from bs4 import BeautifulSoup
 import datetime
 
 
-def collect_all_article_content(soup_object):
-    """This function takes a BeautifulSoup soup object as input and returns all of the HTML content within
-    the specified tags. The returned content contains all of the potential data we will be extracting."""
-
-    all_article_content = soup_object.find("div", class_="lft_art")
-
-    return all_article_content
-
-
-def collect_article_date(all_article_content):
-    """This function takes the subset of HTML data from a webpage provided by the collect_all_article_content()
-    function and parses thru it to find the date that the article was posted."""
-
-    date_element = all_article_content.find("span", class_="info_l")
-    date = date_element.text.split("|")[-1].strip()[9:-6]
-
-    return date
-
-
-def collect_article_title(all_article_content):
-    """This function takes the subset of HTML data from a webpage provided by the collect_all_article_content()
-    function and parses thru it to find the title of the article."""
-
-    title_element = all_article_content.find("h1")
-    title = title_element.text.strip()
-
-    return title
-
-
-def collect_article_body(all_article_content):
-    """This function takes the subset of HTML data from a webpage provided by the collect_all_article_content()
-    function and parses thru it to find the body of the article."""
-
-    article_body = []
-
-    body_element = all_article_content.find_all("p")
-    for paragraph in body_element:
-        article_body.append(paragraph.text.strip())
-
-    body = " ".join(article_body).strip()
-
-    return body
-
-
-def create_filtered_dataframe(data, list_of_columns):
-    """This function takes a list of lists and a list of the column names, creates a DataFrame, and filters that
-    DataFrame by date to keep only date from articles posted on the current date."""
-
-    df = pd.DataFrame(data, columns=list_of_columns)
-    df["date"] = pd.to_datetime(df["date"])
-
-    today = datetime.date.today()
-    today_datetime = pd.to_datetime(today)
-
-    df = df[df["date"] == today_datetime]
-
-    return df
-
-
-
-
 # Change to chinese-news-aggregator directory
 pipeline_directory = Path.home() / "OneDrive/2021/Programming/python/chinese-news-aggregator"
 os.chdir(pipeline_directory)

--- a/chinese-news-aggregator/etl/scraper/scraper_pt_2.py
+++ b/chinese-news-aggregator/etl/scraper/scraper_pt_2.py
@@ -1,19 +1,17 @@
 import os
 import json
-import pandas as pd
-from pathlib import Path
 import requests
 from bs4 import BeautifulSoup
-import datetime
+import helpers
+import constants
 
 
 # Change to chinese-news-aggregator directory
-pipeline_directory = Path.home() / "OneDrive/2021/Programming/python/chinese-news-aggregator"
-os.chdir(pipeline_directory)
+os.chdir(constants.PROJECT_DIRECTORY)
 
 
 # Read in the list of links
-file_source = pipeline_directory / "chinese-news-aggregator/data/potential-new-links.json"
+file_source = constants.PROJECT_DIRECTORY / "chinese-news-aggregator/data/potential-new-links.json"
 with open(file_source, "r") as file:
     secure_links = json.load(file)
 
@@ -27,19 +25,19 @@ for url in secure_links:
     soup = BeautifulSoup(page.content, "html.parser")
 
     # Collect data
-    all_content = collect_all_article_content(soup)
-    date = collect_article_date(soup)
-    title = collect_article_title(soup)
-    body = collect_article_body(soup)
+    all_content = helpers.collect_all_article_content(soup)
+    date = helpers.collect_article_date(soup)
+    title = helpers.collect_article_title(soup)
+    body = helpers.collect_article_body(soup)
     
     # Append to list of lists for DataFrame
     list_of_lists.append([date, title, body])
 
 
 # Convert data to DataFrame and filter by date (only keep today's articles)
-df = create_filtered_dataframe(list_of_lists, list_of_columns=["date", "title", "body"])
+df = helpers.create_filtered_dataframe(list_of_lists, list_of_columns=["date", "title", "body"])
 
 
 # Save DataFame to json file
-file_destination = pipeline_directory / "chinese-news-aggregator/data/article-data-from-new-links.json"
+file_destination = constants.PROJECT_DIRECTORY / "chinese-news-aggregator/data/article-data-from-new-links.json"
 df.to_json(file_destination, orient="records", indent=4)


### PR DESCRIPTION
The scraper and s3 directories have been reorganized to include helpers and constants modules.

Separating the s3_upload_files file using a helpers module for s3 may be unnecessary right now, however when the datasets are expanded to include multiple files from multiple sources, this structure will be beneficial.